### PR TITLE
Fix the issue where filtering comments still triggers reflow

### DIFF
--- a/front/src/pages/game-view/logs/elements.tsx
+++ b/front/src/pages/game-view/logs/elements.tsx
@@ -24,6 +24,7 @@ export const LogWrapper = styled.div<{
   fixedSize: boolean;
 }>`
   width: 100%;
+  contain: layout style;
   display: ${props => (props.fixedSize ? 'block' : 'grid')};
   grid-template-columns:
     minmax(8px, max-content)


### PR DESCRIPTION
Fix the issue where filtering comments still triggers reflow, leading to performance problems. TODO:it still appears when clicking 'Rules.
修复上次修改时增加的bug：筛选发言时触发意外重排导致卡顿
TODO：已知点击【规则】时依然会卡顿，暂时无法修复